### PR TITLE
Change valid_principal_token method.

### DIFF
--- a/lib/faction.rb
+++ b/lib/faction.rb
@@ -109,10 +109,9 @@ module Faction #:nodoc:
     end
 
     # See <tt>SecurityServerClient.isValidPrincipalToken</tt>
-    def valid_principal_token?(token, validation_factors = nil)
+    def valid_principal_token?(token)
       authenticated_crowd_call(:is_valid_principal_token,
-                               token,
-                               {'auth:validationFactors' => convert_validation_factors(validation_factors)})
+                               token)
     end
 
     # See <tt>SecurityServer.updatePrincipalCredential</tt>


### PR DESCRIPTION
Olli, is this the right modification if we wan't to remove the validation_factors?
Or do I have to take something else out also?
**\* verified that Valid_principal_token method is never called with the validation_factors parameter.

I have to change the version number also (right?) but let's do this modification first.
