### PR TITLE
Fixed NullPointerException in Valid_principal_token method.

### DIFF
--- a/lib/faction.rb
+++ b/lib/faction.rb
@@ -110,9 +110,14 @@ module Faction #:nodoc:
 
     # See <tt>SecurityServerClient.isValidPrincipalToken</tt>
     def valid_principal_token?(token, validation_factors = nil)
-      authenticated_crowd_call(:is_valid_principal_token,
+      if (validation_factors.nil? || validation_factors.empty?)
+        authenticated_crowd_call(:is_valid_principal_token,
+                               token,"")
+      else
+        authenticated_crowd_call(:is_valid_principal_token,
                                token,
                                {'auth:validationFactors' => convert_validation_factors(validation_factors)})
+      end
     end
 
     # See <tt>SecurityServer.updatePrincipalCredential</tt>


### PR DESCRIPTION
ValidationFactors field can't be empty when using new Crowd versions.
wsdl:in2/wsdl:in2 needs to be in the message though, so empty string parameter added to the authenticated_crowd_call method call.
